### PR TITLE
Don’t show annoying alert in case the user cancelled

### DIFF
--- a/js/webapp.js
+++ b/js/webapp.js
@@ -36,7 +36,10 @@
                 imagePresenter.style.display = "block";
             };
 
-            pick.onerror = function () { 
+            pick.onerror = function (e) {
+                if (e.target.error && e.target.error.name === 'USER_ABORT')
+                    return;
+
                 alert("Can't view the image!");
             };
         }


### PR DESCRIPTION
There is no need of annoying the user with an unrelated message ("Can't view the image!") when it is the user herself who has cancelled the flow.
