### PR TITLE
Add the nocrop option to the image pick activity

### DIFF
--- a/js/webapp.js
+++ b/js/webapp.js
@@ -24,8 +24,12 @@
             var pick = new MozActivity({
                 name: "pick",
                 data: {
-                    type: ["image/png", "image/jpg", "image/jpeg"]
- }
+                    type: ["image/png", "image/jpg", "image/jpeg"],
+                    // In FxOS 1.3 and before the user is allowed to crop the
+                    // image by default, but this can cause out-of-memory issues
+                    // so we explicitly disable it.
+                    nocrop: true // don't allow the user to crop the image
+                }
             });
 
             pick.onsuccess = function () { 


### PR DESCRIPTION
This should help avoid OOM errors in FxOS 1.3 until we can make no crop the default.
See https://bugzilla.mozilla.org/show_bug.cgi?id=959430

Note that I have not tested this pull request.  (Sorry!)
