### PR TITLE
Adds storage permission to manifest.

### DIFF
--- a/js/webapp.js
+++ b/js/webapp.js
@@ -495,8 +495,8 @@
             };
 
             cursor.onerror = function () {
-                console.log("Error");
-                deviceStoragePicturesDisplay.innerHTML = "<h4>Result from deviceStorage - pictures</h4><p>deviceStorage failed</p>";
+                console.error(this.error);
+                deviceStoragePicturesDisplay.innerHTML = "<h4>Error from deviceStorage - pictures</h4><p>" + (this.error.message || this.error.name || this.error.toString()) + "</p>";
                 deviceStoragePicturesDisplay.style.display = "block";
             };
         };

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -27,6 +27,10 @@
     },
     "geolocation": {
       "description": "Marking out user location"
+    },
+    "device-storage:pictures": {
+        "description": "listing pictures",
+        "access": "readwrite"
     }
   },
   "locales": {


### PR DESCRIPTION
This doesn't actually eliminate the SecurityError on my Keon running 1.3, but I believe it is necessary.  Hopefully, you'll only need to tweak this slightly.

The change to webapp.js allows it to show a useful error messsage.
